### PR TITLE
l10n_fr_siret: Enable to write directly on the SIRET, the SIREN and

### DIFF
--- a/l10n_fr_siret/README.rst
+++ b/l10n_fr_siret/README.rst
@@ -19,6 +19,8 @@ Usage
 
 On the Partner form, users will be able to enter the SIREN
 and NIC numbers, and the SIRET number will be calculated automatically.
+It is possible to write on the SIRET directly, the SIREN and NIC will be
+computed automatically.
 
 The last digits of the SIREN and NIC are control keys:
 Odoo will check their validity when partners are recorded.

--- a/l10n_fr_siret/__manifest__.py
+++ b/l10n_fr_siret/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'French company identity numbers SIRET/SIREN/NIC',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     "category": 'French Localization',
     'author': u'Numérigraphe,Akretion,Odoo Community Association (OCA)',
     'license': 'AGPL-3',

--- a/l10n_fr_siret/models/partner.py
+++ b/l10n_fr_siret/models/partner.py
@@ -32,6 +32,16 @@ class Partner(models.Model):
             else:
                 rec.siret = ''
 
+    @api.multi
+    def _inverse_siret(self):
+        for rec in self:
+            siret = rec.siret
+            if siret:
+                if len(siret) > 9:
+                    rec.write({"siren": siret[:9], "nic": siret[9:]})
+                else:
+                    rec.write({"siren": siret})
+
     @api.constrains('siren', 'nic')
     def _check_siret(self):
         """Check the SIREN's and NIC's keys (last digits)"""
@@ -55,7 +65,7 @@ class Partner(models.Model):
                         % rec.siren)
                 # Check the NIC key (you need both SIREN and NIC to check it)
                 if rec.nic and not _check_luhn(rec.siren + rec.nic):
-                    return UserError(
+                    raise UserError(
                         _("The SIRET '%s%s' is invalid: "
                           "the checksum is wrong.")
                         % (rec.siren, rec.nic))
@@ -77,7 +87,11 @@ class Partner(models.Model):
         "composes the last 5 digits of the SIRET "
         "number.")
     siret = fields.Char(
-        compute='_compute_siret', string='SIRET', size=14, store=True,
+        compute="_compute_siret",
+        inverse="_inverse_siret",
+        string="SIRET",
+        size=14,
+        store=True,
         help="The SIRET number is the official identity number of this "
         "company's office in France. It is composed of the 9 digits "
         "of the SIREN number and the 5 digits of the NIC number, ie. "

--- a/l10n_fr_siret/tests/__init__.py
+++ b/l10n_fr_siret/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_l10n_fr_siret

--- a/l10n_fr_siret/tests/test_l10n_fr_siret.py
+++ b/l10n_fr_siret/tests/test_l10n_fr_siret.py
@@ -1,0 +1,57 @@
+from odoo.exceptions import ValidationError  # type: ignore[import-untyped]
+from odoo.tests import TransactionCase  # type: ignore[import-untyped]
+
+
+class Test(TransactionCase):
+    """Test SIRET."""
+
+    def test_invalid_siret(self):
+        """Ensure checks operate normally when updating the SIRET."""
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "The NIC '0004' is incorrect: it must have exactly 5 digits.",
+        ):
+            self.env["res.partner"].create(
+                {"name": "Test Partner A", "siret": "5018274630004"}
+            )
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "The NIC '0004A' is incorrect: it must have exactly 5 digits.",
+        ):
+            self.env["res.partner"].create(
+                {"name": "Test Partner A", "siret": "5018274630004A"}
+            )
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "The SIREN '50182746' is incorrect: it must have exactly 9 digits.",
+        ):
+            self.env["res.partner"].create(
+                {"name": "Test Partner A", "siret": "50182746"}
+            )
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "The SIREN '50182746C' is incorrect: it must have exactly 9 digits.",
+        ):
+            self.env["res.partner"].create(
+                {"name": "Test Partner A", "siret": "50182746C"}
+            )
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "The SIREN '501827469' is invalid: the checksum is wrong.",
+        ):
+            self.env["res.partner"].create(
+                {"name": "Test Partner B", "siret": "501827469"}
+            )
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "The SIRET '50182746300041' is invalid: the checksum is wrong.",
+        ):
+            self.env["res.partner"].create(
+                {"name": "Test Partner B", "siret": "50182746300041"}
+            )


### PR DESCRIPTION
NIC being computed automatically.
Fix an exception to make it be raised, if the SIRET is invalid.
Add unit tests.