### PR TITLE
l10n_fr_siret: Enable to write directly on the SIRET, the SIREN and

### DIFF
--- a/l10n_fr_siret/README.rst
+++ b/l10n_fr_siret/README.rst
@@ -19,6 +19,8 @@ Usage
 
 On the Partner form, users will be able to enter the SIREN
 and NIC numbers, and the SIRET number will be calculated automatically.
+It is possible to write on the SIRET directly, the SIREN and NIC will be
+computed automatically.
 
 The last digits of the SIREN and NIC are control keys:
 Odoo will check their validity when partners are recorded.

--- a/l10n_fr_siret/__manifest__.py
+++ b/l10n_fr_siret/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'French company identity numbers SIRET/SIREN/NIC',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     "category": 'French Localization',
     'author': u'Numérigraphe,Akretion,Odoo Community Association (OCA)',
     'license': 'AGPL-3',

--- a/l10n_fr_siret/models/partner.py
+++ b/l10n_fr_siret/models/partner.py
@@ -1,5 +1,14 @@
+import logging
+
 from odoo import models, fields, api, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
+
+logger = logging.getLogger(__name__)
+
+try:
+    from stdnum.fr import siren, siret
+except ImportError:
+    logger.debug("Cannot import stdnum")
 
 
 # XXX: this is used for checking various codes such as credit card
@@ -32,6 +41,23 @@ class Partner(models.Model):
             else:
                 rec.siret = ''
 
+    @api.multi
+    def _inverse_siret(self):
+        for rec in self:
+            if rec.siret:
+                if siret.is_valid(rec.siret):
+                    rec.write({"siren": rec.siret[:9], "nic": rec.siret[9:]})
+                elif (
+                    siren.is_valid(rec.siret[:9]) and rec.siret[9:] == "*****"
+                ):
+                    rec.write({"siren": rec.siret[:9], "nic": False})
+                else:
+                    raise ValidationError(
+                        _("SIRET '%s' is invalid.") % rec.siret
+                    )
+            else:
+                rec.write({"siren": False, "nic": False})
+
     @api.constrains('siren', 'nic')
     def _check_siret(self):
         """Check the SIREN's and NIC's keys (last digits)"""
@@ -55,7 +81,7 @@ class Partner(models.Model):
                         % rec.siren)
                 # Check the NIC key (you need both SIREN and NIC to check it)
                 if rec.nic and not _check_luhn(rec.siren + rec.nic):
-                    return UserError(
+                    raise UserError(
                         _("The SIRET '%s%s' is invalid: "
                           "the checksum is wrong.")
                         % (rec.siren, rec.nic))
@@ -77,7 +103,11 @@ class Partner(models.Model):
         "composes the last 5 digits of the SIRET "
         "number.")
     siret = fields.Char(
-        compute='_compute_siret', string='SIRET', size=14, store=True,
+        compute="_compute_siret",
+        inverse="_inverse_siret",
+        string="SIRET",
+        size=14,
+        store=True,
         help="The SIRET number is the official identity number of this "
         "company's office in France. It is composed of the 9 digits "
         "of the SIREN number and the 5 digits of the NIC number, ie. "

--- a/l10n_fr_siret/tests/__init__.py
+++ b/l10n_fr_siret/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_l10n_fr_siret

--- a/l10n_fr_siret/tests/test_l10n_fr_siret.py
+++ b/l10n_fr_siret/tests/test_l10n_fr_siret.py
@@ -1,0 +1,48 @@
+from odoo.exceptions import ValidationError  # type: ignore[import-untyped]
+from odoo.tests import TransactionCase  # type: ignore[import-untyped]
+
+
+class Test(TransactionCase):
+    """Test SIRET."""
+
+    def test_invalid_siret(self):
+        """Ensure checks operate normally when updating the SIRET."""
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "SIRET '5555555560001' is invalid.",
+        ):
+            self.env["res.partner"].create(
+                {"name": "Test Partner A", "siret": "5555555560001"}
+            )
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "SIRET '5555555560001A' is invalid.",
+        ):
+            self.env["res.partner"].create(
+                {"name": "Test Partner A", "siret": "5555555560001A"}
+            )
+
+        with self.assertRaises(ValidationError):
+            self.env["res.partner"].create(
+                {"name": "Test Partner A", "siret": "55555555******"}
+            )
+
+        with self.assertRaises(ValidationError):
+            self.env["res.partner"].create(
+                {"name": "Test Partner A", "siret": "55555555C*****"}
+            )
+
+        with self.assertRaises(ValidationError):
+            self.env["res.partner"].create(
+                {"name": "Test Partner B", "siret": "555555559*****"}
+            )
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "SIRET '55555555600012' is invalid.",
+        ):
+            self.env["res.partner"].create(
+                {"name": "Test Partner B", "siret": "55555555600012"}
+            )


### PR DESCRIPTION
NIC being computed automatically.
Fix an exception to make it be raised, if the SIRET is invalid.
Add unit tests.